### PR TITLE
Improving watch_kafka and gather_process_stats

### DIFF
--- a/monasca_perf/watch_kafka.py
+++ b/monasca_perf/watch_kafka.py
@@ -1,7 +1,7 @@
 import kafka
 
+import json
 import time
-# import json
 
 KAFKA_URL = 'localhost:9092'
 KAFKA_GROUP = 'kafka_python_test'
@@ -12,9 +12,11 @@ c = kafka.consumer.SimpleConsumer(k_client,
                                   KAFKA_GROUP,
                                   KAFKA_TOPIC,
                                   auto_commit=False,
-                                  fetch_size_bytes=1024*1024,
-                                  buffer_size=1024*1024,
+                                  fetch_size_bytes=1024 * 1024,
+                                  buffer_size=1024 * 1024,
                                   max_buffer_size=None)
+
+c.seek(0, 0)
 
 runtime = 60
 
@@ -23,13 +25,49 @@ end_time = 0
 
 total_msgs = 0
 
+hostnames = set()
+
+by_tenant = {}
+
+metrics_out = open("raw_metrics", "w")
+
 for msg in c:
+    total_msgs += 1
+
+    metrics_out.write(msg.message.value)
+
+    metric = json.loads(msg.message.value)
+
+    tenant_id = metric['meta']['tenantId']
+    name = metric['metric']['name']
+
+    if tenant_id not in by_tenant:
+        by_tenant[tenant_id] = {}
+
+    if name not in by_tenant[tenant_id]:
+        by_tenant[tenant_id][name] = 1
+    else:
+        by_tenant[tenant_id][name] += 1
+
     if start_time == 0:
         start_time = time.time()
     if time.time() - start_time > 60:
         end_time = time.time()
         break
-    total_msgs += 1
+
+metrics_out.close()
 
 elapsed_time = end_time - start_time
-print("messages per second: {}".format(total_msgs/elapsed_time))
+print("messages per second: {}".format(total_msgs / elapsed_time))
+
+for tenant, metrics in by_tenant.iteritems():
+    tentant_metrics = 0
+    print("tenant: {}".format(tenant))
+    for k, v in metrics.iteritems():
+        tentant_metrics += v
+    print("total metrics: {}".format(tentant_metrics))
+    print("metrics per second: {}".format(tentant_metrics / elapsed_time))
+
+    for k, v in metrics.iteritems():
+        print("  {} -> {}".format(k, v))
+    print("\n")

--- a/scale_perf/gather_process_stats.py
+++ b/scale_perf/gather_process_stats.py
@@ -62,7 +62,7 @@ def query_measurement_average():
     try:
         ks_client = ksclient.KSClient(**keystone)
     except Exception as ex:
-        print 'Failed to authenticate: {}'.format(ex)
+        print('Failed to authenticate: {}'.format(ex))
         return
 
     mon_client = client.Client('2_0', args.monasca_api_url, token=ks_client.token)
@@ -74,16 +74,33 @@ def query_measurement_average():
         dimensions = metric['dimensions']
         if dimensions['hostname'] not in measurement_averages:
             measurement_averages[dimensions['hostname']] = {}
-        cpu_average = get_measurements_average(mon_client, args.starttime, "process.cpu_perc", dimensions, args.endtime)
-        mem_average = get_measurements_average(mon_client, args.starttime, "process.mem.rss_mbytes", dimensions, args.endtime)
-        measurement_averages[dimensions['hostname']][dimensions['process_name']] = [cpu_average, mem_average]
+
+        cpu_average = get_measurements_average(mon_client,
+                                               args.starttime,
+                                               "process.cpu_perc",
+                                               dimensions,
+                                               args.endtime)
+
+        mem_average = get_measurements_average(mon_client,
+                                               args.starttime,
+                                               "process.mem.rss_mbytes",
+                                               dimensions,
+                                               args.endtime)
+
+        host = dimensions['hostname']
+        proc = dimensions['process_name']
+        measurement_averages[host][proc] = [cpu_average, mem_average]
+
     for host in measurement_averages.keys():
         with open(args.output_directory + host, "w") as output_file:
-            output_file.write("{:<30}| {:^10} | {:^10}\n".format("Process Name", "Cpu %", "Memory mb"))
+            output_file.write("{:<30}| {:^10} | {:^10}\n".
+                              format("Process Name", "Cpu %", "Memory mb"))
             output_file.write("-------------------------------------------------------\n")
             for name in sorted(measurement_averages[host].keys()):
-                output_file.write("{:<30}| {:>10.2f} | {:>10.2f}\n".format(name, measurement_averages[host][name][0],
-                                                                           measurement_averages[host][name][1]))
+                output_file.write("{:<30}| {:>10.2f} | {:>10.2f}\n".
+                                  format(name,
+                                         measurement_averages[host][name][0],
+                                         measurement_averages[host][name][1]))
 
 if __name__ == "__main__":
     sys.exit(query_measurement_average())


### PR DESCRIPTION
watch_kafka now aggregates metric names and counts per tenant and dumps the raw
kafka data out to a raw_metrics file

Fixed formatting on gather_process_stats